### PR TITLE
Added download ro local dir using original name and tried error handling with OperationResult for download.

### DIFF
--- a/DropboxLike.Api/Controllers/FileController.cs
+++ b/DropboxLike.Api/Controllers/FileController.cs
@@ -1,5 +1,9 @@
+using DropboxLike.Domain.Models;
+using DropboxLike.Domain.Repositories;
 using DropboxLike.Domain.Services;
 using Microsoft.AspNetCore.Mvc;
+using File = DropboxLike.Domain.Models.File;
+
 
 namespace DropboxLike.Api.Controllers;
 
@@ -22,28 +26,30 @@ public class FileController : ControllerBase
     
     // TODO: Find a way to return result with correct status code (in case of failure 404, 500, et cetera) using output of FileService call).
 
-    return Ok(response);
+    return Ok(response.Successful);
   }
 
   [HttpGet]
   [Route("Download/{fileId}")]
   public async Task<IActionResult> DownloadFileAsync(string fileId)
   {
-    // var destinationFolderPath = $"/home/godfreyowidi/Downloads/TestsDowloads";
-
-    var result = await _fileService.DownloadSingleFileAsync(fileId);
-    if (result.Successful)
+    var response = await _fileService.DownloadSingleFileAsync(fileId);
+    try
     {
-      var file = result.Result!;
-      // TODO: Consume this result when returning some response.
-      var fileStreamResult = new FileStreamResult(file.FileStream, file.ContentType);
-      return Ok();
+      if (response.Successful)
+      {
+        var file = response.Result;
+        return new FileStreamResult(file.FileStream, file.ContentType);
+      }
+      else
+      {
+        return BadRequest($"Failed to read, {fileId}: {response.FailureMessage!}");
+      }
     }
-    // TODO: Here we have to return some failure response indicating our download operation failed.
-    var exception = result.Exception; // TODO: Be careful! Potentially null!
-    var message = result.FailureMessage!;
-    // If message is "500: Some internal error occurred", we want to return response with status code 500 and response body "Some internal error occurred".
-    return Ok();
+    catch (Exception ex)
+    {
+      return StatusCode(StatusCodes.Status500InternalServerError, $"Failed to read, {fileId}: {ex.Data}-{response.Exception}");
+    }
   }
 
   [HttpDelete]

--- a/DropboxLike.Api/Controllers/FileController.cs
+++ b/DropboxLike.Api/Controllers/FileController.cs
@@ -1,4 +1,3 @@
-using DropboxLike.Domain.Configuration;
 using DropboxLike.Domain.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,6 +19,8 @@ public class FileController : ControllerBase
   public async Task<IActionResult> UploadFileAsync(IFormFile file)
   {
     var response = await _fileService.UploadSingleFileAsync(file);
+    
+    // TODO: Find a way to return result with correct status code (in case of failure 404, 500, et cetera) using output of FileService call).
 
     return Ok(response);
   }
@@ -28,11 +29,21 @@ public class FileController : ControllerBase
   [Route("Download/{fileId}")]
   public async Task<IActionResult> DownloadFileAsync(string fileId)
   {
-    var destinationFolderPath = $"/home/godfreyowidi/Downloads/TestsDowloads";
+    // var destinationFolderPath = $"/home/godfreyowidi/Downloads/TestsDowloads";
 
-    var file = await _fileService.DownloadSingleFileAsync(fileId, destinationFolderPath);
-
-    return File(file, "application/octet-stream", fileId);
+    var result = await _fileService.DownloadSingleFileAsync(fileId);
+    if (result.Successful)
+    {
+      var file = result.Result!;
+      // TODO: Consume this result when returning some response.
+      var fileStreamResult = new FileStreamResult(file.FileStream, file.ContentType);
+      return Ok();
+    }
+    // TODO: Here we have to return some failure response indicating our download operation failed.
+    var exception = result.Exception; // TODO: Be careful! Potentially null!
+    var message = result.FailureMessage!;
+    // If message is "500: Some internal error occurred", we want to return response with status code 500 and response body "Some internal error occurred".
+    return Ok();
   }
 
   [HttpDelete]
@@ -40,6 +51,9 @@ public class FileController : ControllerBase
   public async Task<IActionResult> DeleteFileAsync(string fileId)
   {
     var response = await _fileService.DeleteSingleFileAsync(fileId);
+    
+    // TODO: Find a way to return result with correct status code (in case of failure 404, 500, et cetera) using output of FileService call).
+    
     return Ok(response);
   }
 }

--- a/DropboxLike.Api/Controllers/FileController.cs
+++ b/DropboxLike.Api/Controllers/FileController.cs
@@ -23,10 +23,7 @@ public class FileController : ControllerBase
   public async Task<IActionResult> UploadFileAsync(IFormFile file)
   {
     var response = await _fileService.UploadSingleFileAsync(file);
-    
-    // TODO: Find a way to return result with correct status code (in case of failure 404, 500, et cetera) using output of FileService call).
-
-    return Ok(response.Successful);
+    return StatusCode(response.StatusCode);
   }
 
   [HttpGet]
@@ -34,22 +31,13 @@ public class FileController : ControllerBase
   public async Task<IActionResult> DownloadFileAsync(string fileId)
   {
     var response = await _fileService.DownloadSingleFileAsync(fileId);
-    try
+    if (!response.IsSuccessful)
     {
-      if (response.Successful)
-      {
-        var file = response.Result;
-        return new FileStreamResult(file.FileStream, file.ContentType);
-      }
-      else
-      {
-        return BadRequest($"Failed to read, {fileId}: {response.FailureMessage!}");
-      }
+      var message = $"Failed to download file with ID {fileId} due to '{response.FailureMessage ?? "<>"}'";
+      return StatusCode(response.StatusCode, message);
     }
-    catch (Exception ex)
-    {
-      return StatusCode(StatusCodes.Status500InternalServerError, $"Failed to read, {fileId}: {ex.Data}-{response.Exception}");
-    }
+    var file = response.Value;
+    return new FileStreamResult(file.FileStream, file.ContentType);
   }
 
   [HttpDelete]
@@ -57,9 +45,8 @@ public class FileController : ControllerBase
   public async Task<IActionResult> DeleteFileAsync(string fileId)
   {
     var response = await _fileService.DeleteSingleFileAsync(fileId);
-    
-    // TODO: Find a way to return result with correct status code (in case of failure 404, 500, et cetera) using output of FileService call).
-    
-    return Ok(response);
+    if (response.IsSuccessful) return NoContent();
+    var message = $"Failed to delete file with ID {fileId} due to '{response.FailureMessage ?? "<>"}'";
+    return StatusCode(response.StatusCode, message);
   }
 }

--- a/DropboxLike.Domain/Data/ApplicationDbContext.cs
+++ b/DropboxLike.Domain/Data/ApplicationDbContext.cs
@@ -7,5 +7,5 @@ public class ApplicationDbContext : DbContext
   public ApplicationDbContext(DbContextOptions options) : base(options)
   {
   }
-  public DbSet<FileModel> FileModels { get; set; }
+  public DbSet<FileEntity> FileModels { get; set; }
 }

--- a/DropboxLike.Domain/Data/Entities/FileEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/FileEntity.cs
@@ -1,0 +1,11 @@
+
+using System.ComponentModel.DataAnnotations;
+public class FileEntity
+{
+  [Key]
+  public string? FileKey { get; set; }
+  public string? FileName { get; set; }
+  public string? FileSize { get; set; }
+  public string? ContentType { get; set; }
+  public string? TimeStamp { get; set; }
+}

--- a/DropboxLike.Domain/Models/File.cs
+++ b/DropboxLike.Domain/Models/File.cs
@@ -1,0 +1,7 @@
+﻿namespace DropboxLike.Domain.Models;
+
+public class File
+{
+    public Stream FileStream { get; set; } 
+    public string ContentType { get; set; }
+}

--- a/DropboxLike.Domain/Models/OperationResult.cs
+++ b/DropboxLike.Domain/Models/OperationResult.cs
@@ -1,0 +1,53 @@
+﻿namespace DropboxLike.Domain.Models;
+
+public class OperationResult<T>
+{
+    public bool Successful { get; protected set; }
+    public T? Result { get; protected set; }
+    public string? FailureMessage { get; protected set; }
+    public Exception? Exception { get; protected set; }
+    
+    protected OperationResult(T result)
+    {
+        Successful = true;
+        Result = result;
+        FailureMessage = null;
+        Exception = null;
+    }
+    
+    protected OperationResult(string message)
+    {
+        Successful = false;
+        FailureMessage = message;
+        Exception = null;
+        Result = default;
+    }
+    
+    protected OperationResult(Exception exception, string? message = null)
+    {
+        Successful = false;
+        Exception = exception;
+        FailureMessage = message ?? exception.Message;
+        Result = default;
+    }
+    
+    public static OperationResult<T> SuccessResult(T result)
+    {
+        return new OperationResult<T>(result);
+    }
+    
+    public static OperationResult<T> FailureResult(string message)
+    {
+        return new OperationResult<T>(message);
+    }
+    
+    public static OperationResult<T> ExceptionResult(Exception exception, string? message = null)
+    {
+        return new OperationResult<T>(exception, message);
+    }
+    
+    public bool IsException()
+    {
+        return Exception != null;
+    }
+}

--- a/DropboxLike.Domain/Models/Response/S3Response.cs
+++ b/DropboxLike.Domain/Models/Response/S3Response.cs
@@ -1,7 +1,0 @@
-namespace DropboxLike.Domain.Models.Response;
-
-public class S3Response
-{
-  public int StatusCode { get; set; }
-  public string Message { get; set; } = "";
-}

--- a/DropboxLike.Domain/Repositories/FileRepository.cs
+++ b/DropboxLike.Domain/Repositories/FileRepository.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Net;
 using Amazon;
 using Amazon.S3;
@@ -33,7 +34,7 @@ public class FileRepository : IFileRepository
       using (var newMemoryStream = new MemoryStream())
       {
         await file.CopyToAsync(newMemoryStream);
-        var uploadRequest = new TransferUtilityUploadRequest()
+        var uploadRequest = new TransferUtilityUploadRequest
         {
           InputStream = newMemoryStream,
           Key = $"{Guid.NewGuid()}",
@@ -49,27 +50,27 @@ public class FileRepository : IFileRepository
         {
           FileKey = uploadRequest.Key,
           FileName = file.FileName,
-          FileSize = (file.Length).ToString(),
+          FileSize = file.Length.ToString(),
           ContentType = file.ContentType,
-          TimeStamp = (DateTime.UtcNow).ToString()
+          TimeStamp = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)
         };
 
         _applicationDbContext.FileModels.Add(fileModel);
         // TODO: Check if file already exist
         await _applicationDbContext.SaveChangesAsync();
         
-        return OperationResult<object>.SuccessResult(new object());
+        return OperationResult<object>.Success(new object(), HttpStatusCode.Created);
       }
     }
     catch (AmazonS3Exception exception)
     {
       var message = $"{exception.StatusCode}: {exception.Message}";
-      return OperationResult<object>.ExceptionResult(exception, message);
+      return OperationResult<object>.Fail(exception, message, exception.StatusCode);
     }
     catch (Exception exception)
     {
-      var message = $"500: {exception.Message}";
-      return OperationResult<object>.ExceptionResult(exception, message);
+      var message = $"{HttpStatusCode.InternalServerError}: {exception.Message}";
+      return OperationResult<object>.Fail(exception, message);
     }
   }
 
@@ -88,15 +89,15 @@ public class FileRepository : IFileRepository
         throw new FileNotFoundException("File not Found");
       }
 
-      var objectKey = file?.FileKey?.ToString();
+      var objectKey = file.FileKey;
 
-      ListObjectsV2Request listRequest = new ListObjectsV2Request
+      var listRequest = new ListObjectsV2Request
       {
         BucketName = _bucketName,
       };
-      ListObjectsV2Response listResponse = await _awsS3Client.ListObjectsV2Async(listRequest);
+      var listResponse = await _awsS3Client.ListObjectsV2Async(listRequest);
 
-      foreach (S3Object obj in listResponse.S3Objects)
+      foreach (var obj in listResponse.S3Objects)
       {
         if (file?.FileKey == obj.Key)
         {
@@ -113,7 +114,7 @@ public class FileRepository : IFileRepository
           using var response = await _awsS3Client.GetObjectAsync(request);
           {
             var contentType = response.Headers.ContentType;
-            return OperationResult<File>.SuccessResult(new File
+            return OperationResult<File>.Success(new File
             {
               FileStream = response.ResponseStream,
               ContentType = contentType
@@ -122,17 +123,17 @@ public class FileRepository : IFileRepository
         }
       }
 
-      return OperationResult<File>.FailureResult("404: File not found.");
+      return OperationResult<File>.Fail($"{HttpStatusCode.NotFound}: File not found.", HttpStatusCode.NotFound);
     }
     catch (AmazonS3Exception exception)
     {
       var message = $"{exception.StatusCode}: {exception.Message}";
-      return OperationResult<File>.ExceptionResult(exception, message);
+      return OperationResult<File>.Fail(exception, message, exception.StatusCode);
     }
     catch (Exception exception)
     {
-      var message = $"500: {exception.Message}";
-      return OperationResult<File>.ExceptionResult(exception, message);
+      var message = $"{HttpStatusCode.InternalServerError}: {exception.Message}";
+      return OperationResult<File>.Fail(exception, message);
     }
   }
 
@@ -161,8 +162,8 @@ public class FileRepository : IFileRepository
       _applicationDbContext.FileModels.Remove(results);
       await _applicationDbContext.SaveChangesAsync();
       
-      return OperationResult<object>.FailureResult($"204: File with ID {fileId} has been deleted successfully.");
+      return OperationResult<object>.Success(new object(), HttpStatusCode.NoContent);
     }
-    return OperationResult<object>.FailureResult("404: File not found.");
+    return OperationResult<object>.Fail($"{HttpStatusCode.NotFound}: File not found.", HttpStatusCode.NotFound);
   }
 }

--- a/DropboxLike.Domain/Repositories/IFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/IFileRepository.cs
@@ -1,11 +1,11 @@
 using DropboxLike.Domain.Models;
-using DropboxLike.Domain.Models.Response;
+using File = DropboxLike.Domain.Models.File;
 
 namespace DropboxLike.Domain.Repositories;
 
 public interface IFileRepository
 {
-  Task<S3Response> UploadFileAsync(IFormFile file);
-  Task<byte[]> DownloadFileAsync(string fileId, string destinationFolderPath);
-  Task<S3Response> DeleteFileAsync(string fileId);
+  Task<OperationResult<object>> UploadFileAsync(IFormFile file);
+  Task<OperationResult<File>> DownloadFileAsync(string fileId);
+  Task<OperationResult<object>> DeleteFileAsync(string fileId);
 }

--- a/DropboxLike.Domain/Repositories/IRepository.cs
+++ b/DropboxLike.Domain/Repositories/IRepository.cs
@@ -6,5 +6,5 @@ public interface IRepository<T>
   public void Delete(T _object);
   public void Update(T _object);
   public IEnumerable<T> GetAll();
-  public T GetById(int Id);
+  public T GetById(string id);
 }

--- a/DropboxLike.Domain/Repositories/Repository.cs
+++ b/DropboxLike.Domain/Repositories/Repository.cs
@@ -1,0 +1,37 @@
+using DropboxLike.Domain.Data;
+
+namespace DropboxLike.Domain.Repositories;
+
+public class Repository<T> : IRepository<T> where T : class
+{
+    private readonly ApplicationDbContext _applicationDbContext;
+
+    public Repository(ApplicationDbContext applicationDbContext)
+    {
+        _applicationDbContext = applicationDbContext;
+    }
+    public Task<T> Create(T _object)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Delete(T _object)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Update(T _object)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IEnumerable<T> GetAll()
+    {
+        throw new NotImplementedException();
+    }
+
+    public T GetById(string id)
+    {
+        return _applicationDbContext.Set<T>().Find(id);
+    }
+}

--- a/DropboxLike.Domain/Services/FileService.cs
+++ b/DropboxLike.Domain/Services/FileService.cs
@@ -1,6 +1,6 @@
 using DropboxLike.Domain.Models;
-using DropboxLike.Domain.Models.Response;
 using DropboxLike.Domain.Repositories;
+using File = DropboxLike.Domain.Models.File;
 
 namespace DropboxLike.Domain.Services;
 
@@ -13,17 +13,17 @@ public class FileService : IFileService
         _fileRepository = fileRepository;
     }
 
-    public async Task<S3Response> UploadSingleFileAsync(IFormFile file)
+    public async Task<OperationResult<object>> UploadSingleFileAsync(IFormFile file)
     {
         return await _fileRepository.UploadFileAsync(file);
     }
 
-    public async Task<byte[]> DownloadSingleFileAsync(string fileId, string destinationFolderPath)
+    public async Task<OperationResult<File>> DownloadSingleFileAsync(string fileId)
     {
-        return await _fileRepository.DownloadFileAsync(fileId, destinationFolderPath);
+        return await _fileRepository.DownloadFileAsync(fileId);
     }
 
-    public async Task<S3Response> DeleteSingleFileAsync(string fileId)
+    public async Task<OperationResult<object>> DeleteSingleFileAsync(string fileId)
     {
         return await _fileRepository.DeleteFileAsync(fileId);
     }

--- a/DropboxLike.Domain/Services/IFileService.cs
+++ b/DropboxLike.Domain/Services/IFileService.cs
@@ -8,4 +8,5 @@ public interface IFileService
     Task<OperationResult<object>> UploadSingleFileAsync(IFormFile file);
     Task<OperationResult<File>> DownloadSingleFileAsync(string fileId);
     Task<OperationResult<object>> DeleteSingleFileAsync(string fileId);
+    //FileModel GetObjectByIdAsync(string fileId);
 }

--- a/DropboxLike.Domain/Services/IFileService.cs
+++ b/DropboxLike.Domain/Services/IFileService.cs
@@ -1,11 +1,11 @@
 using DropboxLike.Domain.Models;
-using DropboxLike.Domain.Models.Response;
+using File = DropboxLike.Domain.Models.File;
 
 namespace DropboxLike.Domain.Services;
 
 public interface IFileService
 {
-    Task<S3Response> UploadSingleFileAsync(IFormFile file);
-    Task<byte[]> DownloadSingleFileAsync(string fileId, string destinationFolderPath);
-    Task<S3Response> DeleteSingleFileAsync(string fileId);
+    Task<OperationResult<object>> UploadSingleFileAsync(IFormFile file);
+    Task<OperationResult<File>> DownloadSingleFileAsync(string fileId);
+    Task<OperationResult<object>> DeleteSingleFileAsync(string fileId);
 }


### PR DESCRIPTION
## Please check it out
* Implemented download file to local directory with original name 
* Used `OperationResult` pattern you implement on Sunday to handle error for download in controllers when the service is called.
* I tried it out with two scenarios: 
      - *When I disconnected the database*
      - *When I provided a wrong `fileId`*
* See attached:
![Screenshot from 2023-05-24 20-07-24](https://github.com/godfreyowidi/DropboxLike/assets/39213905/e624b2d5-3289-4913-bad5-381deb18b002)

Please let me know what you think about the example: Should I catch the error when the service is called really? I tried debugging with those scenarios and its like am missing something.
Also I dont understand why am gettitng `Redundant 'Else' statement` in line 44 inside the controller

**When I provided a wrong `fileId`, I got a 500 status code. See attached**
What am struggling to understand is if we can only return 500 status code when we call our services and not for example 404 in this case
![Screenshot from 2023-05-24 22-21-23](https://github.com/godfreyowidi/DropboxLike/assets/39213905/cba8374f-a6d8-4131-8d43-5006196e7693)
![Screenshot from 2023-05-24 22-16-47](https://github.com/godfreyowidi/DropboxLike/assets/39213905/3695dd4f-32d8-4ea4-b75e-8a9172589ca5)
