### PR TITLE
Add file share to authenticated user 

### DIFF
--- a/DropboxLike.Api/Controllers/BaseController.cs
+++ b/DropboxLike.Api/Controllers/BaseController.cs
@@ -7,7 +7,12 @@ public class BaseController : ControllerBase
 {
     protected string GetUserIdFromClaim()
     {
-        return HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)!.Value;
+        var signedInUser = HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)!.Value;
+
+        if (signedInUser is null)
+            return "Please sign in to continue.";
+
+        return signedInUser;
     }
 
 }

--- a/DropboxLike.Api/Controllers/FileController.cs
+++ b/DropboxLike.Api/Controllers/FileController.cs
@@ -48,11 +48,12 @@ public class FileController : BaseController
   [Route("List")]
   public async Task<IActionResult> ListFilesAsync()
   {
+    // TODO: List files operation needs to be scoped to user, otherwise other users' files will be included in response.
     var userId = GetUserIdFromClaim();
     
     var response = await _fileService.ListBucketFilesAsync();
     
-    return Ok(response);
+    return Ok(response.Value);
   }
 
   [HttpDelete]

--- a/DropboxLike.Api/Controllers/FileController.cs
+++ b/DropboxLike.Api/Controllers/FileController.cs
@@ -48,10 +48,9 @@ public class FileController : BaseController
   [Route("List")]
   public async Task<IActionResult> ListFilesAsync()
   {
-    // TODO: List files operation needs to be scoped to user, otherwise other users' files will be included in response.
     var userId = GetUserIdFromClaim();
     
-    var response = await _fileService.ListBucketFilesAsync();
+    var response = await _fileService.ListBucketFilesAsync(userId);
     
     return Ok(response.Value);
   }

--- a/DropboxLike.Api/Controllers/ShareFileController.cs
+++ b/DropboxLike.Api/Controllers/ShareFileController.cs
@@ -22,7 +22,10 @@ public class ShareFileController : BaseController
     {
         var response = await _shareFileService.ShareFileWithUserAsync(userId, fileKey);
 
-        return Ok();
+        if (response.IsSuccessful) return Ok();
+        
+        var message = $"Failed to create shared file for user with ID {userId} and file with key {fileKey} due to '{response.FailureMessage ?? "<>"}'";
+        return StatusCode(response.StatusCode, message);
     }
 
     [HttpGet]
@@ -32,7 +35,11 @@ public class ShareFileController : BaseController
         var userId = GetUserIdFromClaim();
 
         var response = await _shareFileService.GetSharedFilesByUserId(userId);
+        
+        if (response.IsSuccessful) return Ok(response.Value);
+        
+        var message = $"Failed to get shared files for user with ID {userId} due to '{response.FailureMessage ?? "<>"}'";
+        return StatusCode(response.StatusCode, message);
 
-        return Ok(response);
     }
 }

--- a/DropboxLike.Api/Controllers/ShareFileController.cs
+++ b/DropboxLike.Api/Controllers/ShareFileController.cs
@@ -5,7 +5,7 @@ namespace DropboxLike.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class ShareFileController : ControllerBase
+public class ShareFileController : BaseController
 {
     private readonly IShareFileService _shareFileService;
 
@@ -16,10 +16,11 @@ public class ShareFileController : ControllerBase
 
     [HttpGet]
     [Route("share")]
-    public async Task<IActionResult> ShareFileAsync(FileEntity file)
+    public async Task<IActionResult> GetSharedFilesByUserIdAsync()
     {
+        var userId = GetUserIdFromClaim();
 
-        var response = await _shareFileService.ShareFileServiceAsync(file);
+        var response = await _shareFileService.GetSharedFilesByUserId(userId);
 
         return Ok(response);
     }

--- a/DropboxLike.Api/Controllers/ShareFileController.cs
+++ b/DropboxLike.Api/Controllers/ShareFileController.cs
@@ -1,4 +1,6 @@
-﻿using DropboxLike.Domain.Services.Share;
+﻿using DropboxLike.Domain.Models;
+using DropboxLike.Domain.Services.Share;
+using DropboxLike.Domain.Services.User;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,10 +12,12 @@ namespace DropboxLike.Api.Controllers;
 public class ShareFileController : BaseController
 {
     private readonly IShareFileService _shareFileService;
+    private readonly IUserService _userService;
 
-    public ShareFileController(IShareFileService shareFileService)
+    public ShareFileController(IShareFileService shareFileService, IUserService userService)
     {
         _shareFileService = shareFileService;
+        _userService = userService;
     }
 
     [HttpPost]
@@ -23,8 +27,9 @@ public class ShareFileController : BaseController
         var response = await _shareFileService.ShareFileWithUserAsync(userId, fileKey);
 
         if (response.IsSuccessful) return Ok();
-        
-        var message = $"Failed to create shared file for user with ID {userId} and file with key {fileKey} due to '{response.FailureMessage ?? "<>"}'";
+
+        var message =
+            $"Failed to create shared file for user with ID {userId} and file with key {fileKey} due to '{response.FailureMessage ?? "<>"}'";
         return StatusCode(response.StatusCode, message);
     }
 
@@ -35,11 +40,35 @@ public class ShareFileController : BaseController
         var userId = GetUserIdFromClaim();
 
         var response = await _shareFileService.GetSharedFilesByUserId(userId);
-        
+
         if (response.IsSuccessful) return Ok(response.Value);
-        
-        var message = $"Failed to get shared files for user with ID {userId} due to '{response.FailureMessage ?? "<>"}'";
+
+        var message =
+            $"Failed to get shared files for user with ID {userId} due to '{response.FailureMessage ?? "<>"}'";
         return StatusCode(response.StatusCode, message);
 
+    }
+
+    [HttpPost]
+    [Route("shareByEmail")]
+    public async Task<IActionResult> ShareWithUserByEmailAsync([FromBody] Share model)
+    {
+        var result = await _userService.GetUserIdByEmailAddressAsync(model.Email);
+
+        if (!result.IsSuccessful)
+        {
+            return BadRequest("User with that email is not a registered user.");
+        }
+
+        var userId = result.Value;
+
+        var shareResult = await _shareFileService.ShareFileWithUserAsync(userId, model.FileId);
+
+        if (shareResult.IsSuccessful)
+        {
+            return Ok("File Share Successfully.");
+        }
+
+        return BadRequest("An error occurred while sharing the file. Try again later.");
     }
 }

--- a/DropboxLike.Api/Controllers/ShareFileController.cs
+++ b/DropboxLike.Api/Controllers/ShareFileController.cs
@@ -1,10 +1,12 @@
 ﻿using DropboxLike.Domain.Services.Share;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DropboxLike.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class ShareFileController : BaseController
 {
     private readonly IShareFileService _shareFileService;

--- a/DropboxLike.Api/Controllers/ShareFileController.cs
+++ b/DropboxLike.Api/Controllers/ShareFileController.cs
@@ -16,8 +16,17 @@ public class ShareFileController : BaseController
         _shareFileService = shareFileService;
     }
 
-    [HttpGet]
+    [HttpPost]
     [Route("share")]
+    public async Task<IActionResult> ShareFileWithUserAsync([FromForm] string userId, [FromForm] string fileKey)
+    {
+        var response = await _shareFileService.ShareFileWithUserAsync(userId, fileKey);
+
+        return Ok();
+    }
+
+    [HttpGet]
+    [Route("sharedfile")]
     public async Task<IActionResult> GetSharedFilesByUserIdAsync()
     {
         var userId = GetUserIdFromClaim();

--- a/DropboxLike.Api/Controllers/ShareFileController.cs
+++ b/DropboxLike.Api/Controllers/ShareFileController.cs
@@ -1,0 +1,26 @@
+﻿using DropboxLike.Domain.Services.Share;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DropboxLike.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ShareFileController : ControllerBase
+{
+    private readonly IShareFileService _shareFileService;
+
+    public ShareFileController(IShareFileService shareFileService)
+    {
+        _shareFileService = shareFileService;
+    }
+
+    [HttpGet]
+    [Route("share")]
+    public async Task<IActionResult> ShareFileAsync(FileEntity file)
+    {
+
+        var response = await _shareFileService.ShareFileServiceAsync(file);
+
+        return Ok(response);
+    }
+}

--- a/DropboxLike.Api/Program.cs
+++ b/DropboxLike.Api/Program.cs
@@ -2,9 +2,13 @@ using System.Security.Claims;
 using System.Text;
 using DropboxLike.Domain.Configuration;
 using DropboxLike.Domain.Data;
+using DropboxLike.Domain.Models;
+using DropboxLike.Domain.Repositories.Email;
 using DropboxLike.Domain.Repositories.File;
+using DropboxLike.Domain.Repositories.Share;
 using DropboxLike.Domain.Repositories.User;
 using DropboxLike.Domain.Services.File;
+using DropboxLike.Domain.Services.Share;
 using DropboxLike.Domain.Services.Token;
 using DropboxLike.Domain.Services.User;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -36,13 +40,22 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 // 2. Add lowest layer components, namely repositories.
 builder.Services.AddScoped<IFileRepository, FileRepository>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
+builder.Services.AddScoped<IShareFileRepository, ShareFileRepository>();
 
 // 3. Add higher layer components, namely services.
 builder.Services.AddScoped<IFileService, FileService>();
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IShareFileService, ShareFileService>();
 
 // 4. Add even higher layer components, namely controllers and the related authorization and authentication.
 builder.Services.AddScoped<ITokenManager, TokenManager>();
+
+// Add email service configuratio
+var emailConfig = builder.Configuration.GetSection("EmailConfiguration").Get<EmailConfiguration>();
+
+builder.Services.AddScoped<IEmailRepository, EmailRepository>();
+builder.Services.AddSingleton(emailConfig);
+
 
 // 5. Add authentication as JWT validation logic.
 builder.Services.AddAuthentication(x =>

--- a/DropboxLike.Api/Program.cs
+++ b/DropboxLike.Api/Program.cs
@@ -2,8 +2,6 @@ using System.Security.Claims;
 using System.Text;
 using DropboxLike.Domain.Configuration;
 using DropboxLike.Domain.Data;
-using DropboxLike.Domain.Models;
-using DropboxLike.Domain.Repositories.Email;
 using DropboxLike.Domain.Repositories.File;
 using DropboxLike.Domain.Repositories.Share;
 using DropboxLike.Domain.Repositories.User;
@@ -49,13 +47,6 @@ builder.Services.AddScoped<IShareFileService, ShareFileService>();
 
 // 4. Add even higher layer components, namely controllers and the related authorization and authentication.
 builder.Services.AddScoped<ITokenManager, TokenManager>();
-
-// Add email service configuratio
-var emailConfig = builder.Configuration.GetSection("EmailConfiguration").Get<EmailConfiguration>();
-
-builder.Services.AddScoped<IEmailRepository, EmailRepository>();
-builder.Services.AddSingleton(emailConfig);
-
 
 // 5. Add authentication as JWT validation logic.
 builder.Services.AddAuthentication(x =>

--- a/DropboxLike.Domain/Data/ApplicationDbContext.cs
+++ b/DropboxLike.Domain/Data/ApplicationDbContext.cs
@@ -8,6 +8,12 @@ public class ApplicationDbContext : DbContext
   public ApplicationDbContext(DbContextOptions options) : base(options)
   {
   }
+
+  public ApplicationDbContext()
+  {
+  }
+
   public DbSet<FileEntity>? FileModels { get; set; }
   public DbSet<UserEntity>? AppUsers { get; set;  }
+  public DbSet<ShareEntity>? SharedFiles { get; set; }
 }

--- a/DropboxLike.Domain/Data/ApplicationDbContext.cs
+++ b/DropboxLike.Domain/Data/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 using DropboxLike.Domain.Data.Entities;
+using DropboxLike.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace DropboxLike.Domain.Data;
@@ -18,7 +19,14 @@ public class ApplicationDbContext : DbContext
     modelBuilder.Entity<UserEntity>()
       .HasIndex(u => u.Email)
       .IsUnique();
-
+    
+    modelBuilder.Entity<ShareEntity>()
+      .HasKey(s => s.ShareId);
+    
+    modelBuilder.Entity<ShareEntity>()
+      .HasIndex(k => new { k.UserId, k.FileId })
+      .IsUnique();
+    
     base.OnModelCreating(modelBuilder);
   }
 }

--- a/DropboxLike.Domain/Data/ApplicationDbContext.cs
+++ b/DropboxLike.Domain/Data/ApplicationDbContext.cs
@@ -8,12 +8,17 @@ public class ApplicationDbContext : DbContext
   public ApplicationDbContext(DbContextOptions options) : base(options)
   {
   }
-
-  public ApplicationDbContext()
-  {
-  }
-
+    
   public DbSet<FileEntity>? FileModels { get; set; }
   public DbSet<UserEntity>? AppUsers { get; set;  }
   public DbSet<ShareEntity>? SharedFiles { get; set; }
+
+  protected override void OnModelCreating(ModelBuilder modelBuilder)
+  {
+    modelBuilder.Entity<UserEntity>()
+      .HasIndex(u => u.Email)
+      .IsUnique();
+
+    base.OnModelCreating(modelBuilder);
+  }
 }

--- a/DropboxLike.Domain/Data/Entities/FileEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/FileEntity.cs
@@ -6,6 +6,7 @@ public class FileEntity
   public string? FileKey { get; set; }
   public string? FileName { get; set; }
   public string? FileSize { get; set; }
+  public string? FilePath { get; set; }
   public string? ContentType { get; set; }
   public string? TimeStamp { get; set; }
 }

--- a/DropboxLike.Domain/Data/Entities/ShareEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/ShareEntity.cs
@@ -1,12 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using DropboxLike.Domain.Models;
 
 namespace DropboxLike.Domain.Data.Entities;
 
 public class ShareEntity
 {
     [Key]
+    public int ShareId { get; set; }
     public string UserId { get; set; }
     public string FileId { get; set; }
-    public string SenderEmail { get; set; } = "";
-    public string RecipientEmail { get; set; } = "";
+
+    public UserEntity User { get; set; }
 }

--- a/DropboxLike.Domain/Data/Entities/ShareEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/ShareEntity.cs
@@ -9,5 +9,13 @@ public class ShareEntity
     public string FileId { get; set; }
     public string SenderEmail { get; set; }
     public string RecipientEmail { get; set; }
-    public string AccessPermissions { get; set; }
+    public AccessPermission AccessPermissions { get; set; }
+}
+
+public enum AccessPermission
+{
+    None,
+    Read,
+    Write,
+    ReadWrite
 }

--- a/DropboxLike.Domain/Data/Entities/ShareEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/ShareEntity.cs
@@ -7,15 +7,6 @@ public class ShareEntity
     [Key]
     public string UserId { get; set; }
     public string FileId { get; set; }
-    public string SenderEmail { get; set; }
-    public string RecipientEmail { get; set; }
-    public AccessPermission AccessPermissions { get; set; }
-}
-
-public enum AccessPermission
-{
-    None,
-    Read,
-    Write,
-    ReadWrite
+    public string SenderEmail { get; set; } = "";
+    public string RecipientEmail { get; set; } = "";
 }

--- a/DropboxLike.Domain/Data/Entities/ShareEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/ShareEntity.cs
@@ -1,0 +1,11 @@
+﻿namespace DropboxLike.Domain.Data.Entities;
+
+public class ShareEntity
+{
+    public string FileId { get; set; }
+    public string UserId { get; set; }
+    public string SenderEmail { get; set; }
+    public string RecipientEmail { get; set; }
+    public string AccessPermissions { get; set; }
+}
+// userid - foreign id

--- a/DropboxLike.Domain/Data/Entities/ShareEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/ShareEntity.cs
@@ -1,11 +1,13 @@
-﻿namespace DropboxLike.Domain.Data.Entities;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace DropboxLike.Domain.Data.Entities;
 
 public class ShareEntity
 {
-    public string FileId { get; set; }
+    [Key]
     public string UserId { get; set; }
+    public string FileId { get; set; }
     public string SenderEmail { get; set; }
     public string RecipientEmail { get; set; }
     public string AccessPermissions { get; set; }
 }
-// userid - foreign id

--- a/DropboxLike.Domain/Data/Entities/UserEntity.cs
+++ b/DropboxLike.Domain/Data/Entities/UserEntity.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace DropboxLike.Domain.Data.Entities;
 
@@ -8,6 +10,12 @@ public class UserEntity
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public string? Id { get; set;  }
+    
+    [Required]
+    [MaxLength(30)]
+    [EmailAddress]
     public string? Email { get; set; }
+    
+    [Required]
     public string? Password { get; set; }
 }

--- a/DropboxLike.Domain/DropboxLike.Domain.csproj
+++ b/DropboxLike.Domain/DropboxLike.Domain.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.103.45" />
+    <PackageReference Include="MailKit" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.20" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">

--- a/DropboxLike.Domain/DropboxLike.Domain.csproj
+++ b/DropboxLike.Domain/DropboxLike.Domain.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.103.45" />
-    <PackageReference Include="MailKit" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.20" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">

--- a/DropboxLike.Domain/Migrations/20230810155520_AddShareEntity.Designer.cs
+++ b/DropboxLike.Domain/Migrations/20230810155520_AddShareEntity.Designer.cs
@@ -3,6 +3,7 @@ using DropboxLike.Domain.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropboxLike.Domain.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230810155520_AddShareEntity")]
+    partial class AddShareEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropboxLike.Domain/Migrations/20230810155520_AddShareEntity.cs
+++ b/DropboxLike.Domain/Migrations/20230810155520_AddShareEntity.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropboxLike.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShareEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FilePath",
+                table: "FileModels",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "SharedFiles",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    FileId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SenderEmail = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    RecipientEmail = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    AccessPermissions = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SharedFiles", x => x.UserId);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SharedFiles");
+
+            migrationBuilder.DropColumn(
+                name: "FilePath",
+                table: "FileModels");
+        }
+    }
+}

--- a/DropboxLike.Domain/Migrations/20230905134536_UpdateShareEntity.Designer.cs
+++ b/DropboxLike.Domain/Migrations/20230905134536_UpdateShareEntity.Designer.cs
@@ -3,6 +3,7 @@ using DropboxLike.Domain.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropboxLike.Domain.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230905134536_UpdateShareEntity")]
+    partial class UpdateShareEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropboxLike.Domain/Migrations/20230905134536_UpdateShareEntity.cs
+++ b/DropboxLike.Domain/Migrations/20230905134536_UpdateShareEntity.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropboxLike.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateShareEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AccessPermissions",
+                table: "SharedFiles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Password",
+                table: "AppUsers",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "AppUsers",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppUsers_Email",
+                table: "AppUsers",
+                column: "Email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AppUsers_Email",
+                table: "AppUsers");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AccessPermissions",
+                table: "SharedFiles",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Password",
+                table: "AppUsers",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "AppUsers",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(30)",
+                oldMaxLength: 30);
+        }
+    }
+}

--- a/DropboxLike.Domain/Migrations/20230905143943_UpdateEmailDefault.Designer.cs
+++ b/DropboxLike.Domain/Migrations/20230905143943_UpdateEmailDefault.Designer.cs
@@ -3,6 +3,7 @@ using DropboxLike.Domain.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropboxLike.Domain.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230905143943_UpdateEmailDefault")]
+    partial class UpdateEmailDefault
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropboxLike.Domain/Migrations/20230905143943_UpdateEmailDefault.cs
+++ b/DropboxLike.Domain/Migrations/20230905143943_UpdateEmailDefault.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropboxLike.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateEmailDefault : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/DropboxLike.Domain/Migrations/20230908151402_UpdateShareEntityCompositeKey.Designer.cs
+++ b/DropboxLike.Domain/Migrations/20230908151402_UpdateShareEntityCompositeKey.Designer.cs
@@ -3,6 +3,7 @@ using DropboxLike.Domain.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DropboxLike.Domain.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230908151402_UpdateShareEntityCompositeKey")]
+    partial class UpdateShareEntityCompositeKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DropboxLike.Domain/Migrations/20230908151402_UpdateShareEntityCompositeKey.cs
+++ b/DropboxLike.Domain/Migrations/20230908151402_UpdateShareEntityCompositeKey.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DropboxLike.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateShareEntityCompositeKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_SharedFiles",
+                table: "SharedFiles");
+
+            migrationBuilder.DropColumn(
+                name: "RecipientEmail",
+                table: "SharedFiles");
+
+            migrationBuilder.DropColumn(
+                name: "SenderEmail",
+                table: "SharedFiles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileId",
+                table: "SharedFiles",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ShareId",
+                table: "SharedFiles",
+                type: "int",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("SqlServer:Identity", "1, 1");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_SharedFiles",
+                table: "SharedFiles",
+                column: "ShareId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SharedFiles_UserId_FileId",
+                table: "SharedFiles",
+                columns: new[] { "UserId", "FileId" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SharedFiles_AppUsers_UserId",
+                table: "SharedFiles",
+                column: "UserId",
+                principalTable: "AppUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SharedFiles_AppUsers_UserId",
+                table: "SharedFiles");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_SharedFiles",
+                table: "SharedFiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SharedFiles_UserId_FileId",
+                table: "SharedFiles");
+
+            migrationBuilder.DropColumn(
+                name: "ShareId",
+                table: "SharedFiles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileId",
+                table: "SharedFiles",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RecipientEmail",
+                table: "SharedFiles",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SenderEmail",
+                table: "SharedFiles",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_SharedFiles",
+                table: "SharedFiles",
+                column: "UserId");
+        }
+    }
+}

--- a/DropboxLike.Domain/Models/FileMetadata.cs
+++ b/DropboxLike.Domain/Models/FileMetadata.cs
@@ -1,0 +1,11 @@
+﻿namespace DropboxLike.Domain.Models;
+
+public class FileMetadata
+{
+    public string? FileKey { get; set; }
+    public string? FileName { get; set; }
+    public string? FileSize { get; set; }
+    public string? FilePath { get; set; }
+    public string? ContentType { get; set; }
+    public string? TimeStamp { get; set; }
+}

--- a/DropboxLike.Domain/Models/Share.cs
+++ b/DropboxLike.Domain/Models/Share.cs
@@ -1,0 +1,7 @@
+﻿namespace DropboxLike.Domain.Models;
+
+public class Share
+{
+    public string Email { get; set; }
+    public string FileId { get; set; }
+}

--- a/DropboxLike.Domain/Repositories/File/FileRepository.cs
+++ b/DropboxLike.Domain/Repositories/File/FileRepository.cs
@@ -152,11 +152,16 @@ public class FileRepository : IFileRepository
     }
   }
 
-  public async Task<OperationResult<List<FileMetadata>>> ListFilesAsync()
+  public async Task<OperationResult<List<FileMetadata>>> ListFilesAsync(string userId)
   {
     try
     {
-      // TODO: Fix this implementation, it should take a user ID and ONLY RETURN FILES OWNED BY THAT USER.
+      var user = await _applicationDbContext.AppUsers!.FirstOrDefaultAsync(u => u.Id == userId);
+      
+      if (user == null)
+      {
+        return OperationResult<List<FileMetadata>>.Fail("User not found.", HttpStatusCode.NotFound);
+      }
       var files = await _applicationDbContext
         .FileModels!
         .Select(file => new FileMetadata
@@ -164,7 +169,7 @@ public class FileRepository : IFileRepository
           FileKey = file.FileKey,
           FileName = file.FileName,
           FileSize = file.FileSize,
-          FilePath = file.FilePath,
+          FilePath = $"user_{user.Id}/{file.FileName}",
           ContentType = file.ContentType,
           TimeStamp = file.TimeStamp
         })

--- a/DropboxLike.Domain/Repositories/File/FileRepository.cs
+++ b/DropboxLike.Domain/Repositories/File/FileRepository.cs
@@ -158,17 +158,29 @@ public class FileRepository : IFileRepository
     }
   }
 
-  public async Task<OperationResult<List<FileEntity>>> ListFilesAsync()
+  public async Task<OperationResult<List<FileMetadata>>> ListFilesAsync()
   {
     try
     {
-      var files = await _applicationDbContext.FileModels!.ToListAsync();
-      return OperationResult<List<FileEntity>>.Success(files);
+      // TODO: Fix this implementation, it should take a user ID and ONLY RETURN FILES OWNED BY THAT USER.
+      var files = await _applicationDbContext
+        .FileModels!
+        .Select(file => new FileMetadata
+        {
+          FileKey = file.FileKey,
+          FileName = file.FileName,
+          FileSize = file.FileSize,
+          FilePath = file.FilePath,
+          ContentType = file.ContentType,
+          TimeStamp = file.TimeStamp
+        })
+        .ToListAsync();
+      return OperationResult<List<FileMetadata>>.Success(files);
     }
     catch (Exception exception)
     {
       var message = $"{HttpStatusCode.InternalServerError}: {exception.Message}";
-      return OperationResult<List<FileEntity>>.Fail(exception, message);
+      return OperationResult<List<FileMetadata>>.Fail(exception, message);
     }
   }
 

--- a/DropboxLike.Domain/Repositories/File/IFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/File/IFileRepository.cs
@@ -7,5 +7,5 @@ public interface IFileRepository
   Task<OperationResult<object>> UploadFileAsync(IFormFile file, string userId);
   Task<OperationResult<Models.File>> DownloadFileAsync(string fileId);
   Task<OperationResult<object>> DeleteFileAsync(string fileId);
-  Task<OperationResult<List<FileMetadata>>> ListFilesAsync();
+  Task<OperationResult<List<FileMetadata>>> ListFilesAsync(string userId);
 }

--- a/DropboxLike.Domain/Repositories/File/IFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/File/IFileRepository.cs
@@ -7,5 +7,5 @@ public interface IFileRepository
   Task<OperationResult<object>> UploadFileAsync(IFormFile file, string userId);
   Task<OperationResult<Models.File>> DownloadFileAsync(string fileId);
   Task<OperationResult<object>> DeleteFileAsync(string fileId);
-  Task<OperationResult<List<FileEntity>>> ListFilesAsync();
+  Task<OperationResult<List<FileMetadata>>> ListFilesAsync();
 }

--- a/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
@@ -1,6 +1,9 @@
-﻿namespace DropboxLike.Domain.Repositories.Share;
+﻿using DropboxLike.Domain.Data.Entities;
+using DropboxLike.Domain.Models;
+
+namespace DropboxLike.Domain.Repositories.Share;
 
 public interface IShareFileRepository
 {
-    
+    List<ShareEntity> GetSharedFilesForUser(string loggedInUserEmail);
 }

--- a/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
@@ -1,9 +1,6 @@
-﻿using DropboxLike.Domain.Data.Entities;
-using DropboxLike.Domain.Models;
-
-namespace DropboxLike.Domain.Repositories.Share;
+﻿namespace DropboxLike.Domain.Repositories.Share;
 
 public interface IShareFileRepository
 {
-    List<ShareEntity> GetSharedFilesForUser(string loggedInUserEmail);
+    Task<List<FileEntity>> GetSharedFilesByUserId(string userId);
 }

--- a/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
@@ -5,4 +5,6 @@ namespace DropboxLike.Domain.Repositories.Share;
 public interface IShareFileRepository
 {
     Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
+    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey);
+
 }

--- a/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
@@ -5,7 +5,7 @@ namespace DropboxLike.Domain.Repositories.Share;
 
 public interface IShareFileRepository
 {
-    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission);
-    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission);
+    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
+    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey);
 
 }

--- a/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
@@ -1,6 +1,8 @@
-﻿namespace DropboxLike.Domain.Repositories.Share;
+﻿using DropboxLike.Domain.Models;
+
+namespace DropboxLike.Domain.Repositories.Share;
 
 public interface IShareFileRepository
 {
-    Task<List<FileEntity>> GetSharedFilesByUserId(string userId);
+    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
 }

--- a/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
@@ -1,10 +1,11 @@
-﻿using DropboxLike.Domain.Models;
+﻿using DropboxLike.Domain.Data.Entities;
+using DropboxLike.Domain.Models;
 
 namespace DropboxLike.Domain.Repositories.Share;
 
 public interface IShareFileRepository
 {
-    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
-    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey);
+    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission);
+    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission);
 
 }

--- a/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/IShareFileRepository.cs
@@ -1,0 +1,6 @@
+﻿namespace DropboxLike.Domain.Repositories.Share;
+
+public interface IShareFileRepository
+{
+    
+}

--- a/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
@@ -1,4 +1,5 @@
 ﻿using DropboxLike.Domain.Data;
+using DropboxLike.Domain.Data.Entities;
 using DropboxLike.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -13,12 +14,28 @@ public class ShareFileRepository : IShareFileRepository
         _applicationDbContext = applicationDbContext;
     }
 
+    public async Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey)
+    {
+        var sharedFile = new ShareEntity
+        {
+            UserId = userId,
+            FileId = fileKey,
+            SenderEmail = "",
+            RecipientEmail = "",
+            AccessPermissions = ""
+        };
+        await _applicationDbContext.SharedFiles!.AddAsync(sharedFile);
+        await _applicationDbContext.SaveChangesAsync();
+
+        return OperationResult<string>.Success("File share successfully");
+    }
+
     public async Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId)
     {
         var sharedFiles = await _applicationDbContext.SharedFiles!
             .Where(file => file.UserId == userId)
             .Join(
-                _applicationDbContext.FileModels,
+                _applicationDbContext.FileModels!,
                 sharedFile => sharedFile.FileId,
                 file => file.FileKey,
                 (sharedFile, file) => file)

--- a/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
@@ -1,36 +1,26 @@
-﻿using System.Net.Mime;
-using Amazon;
-using Amazon.S3;
-using Amazon.S3.Model;
-using DropboxLike.Domain.Configuration;
-using DropboxLike.Domain.Data;
-using DropboxLike.Domain.Data.Entities;
-using DropboxLike.Domain.Models;
-using Microsoft.Extensions.Options;
+﻿using DropboxLike.Domain.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace DropboxLike.Domain.Repositories.Share;
 
 public class ShareFileRepository : IShareFileRepository
 {
-    private readonly string? _bucketName;
     private readonly ApplicationDbContext _applicationDbContext;
-    private readonly IAmazonS3 _awsS3Client;
 
-    public ShareFileRepository(IOptions<AwsConfiguration> options, ApplicationDbContext applicationDbContext)
+    public ShareFileRepository(ApplicationDbContext applicationDbContext)
     {
-        var configuration = options.Value;
-        _bucketName = configuration.BucketName;
-        _awsS3Client = new AmazonS3Client(configuration.AwsAccessKey, configuration.AwsSecretAccessKey, RegionEndpoint.GetBySystemName(configuration.Region));
         _applicationDbContext = applicationDbContext;
     }
 
-    public List<ShareEntity> GetSharedFilesForUser(string loggedInUserEmail)
+    public Task<List<FileEntity>> GetSharedFilesByUserId(string userId)
     {
-        // conditions
-        // relate email to the user id
-        using var dbContext = new ApplicationDbContext();
-        return dbContext.SharedFiles!
-            .Where(file => file.RecipientEmail == loggedInUserEmail)
-            .ToList();
+        return _applicationDbContext.SharedFiles!
+            .Where(file => file.UserId == userId)
+            .Join(
+                _applicationDbContext.FileModels,
+                sharedFile => sharedFile.FileId,
+                file => file.FileKey,
+                (sharedFile, file) => file)
+            .ToListAsync();
     }
 }

--- a/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
@@ -1,0 +1,38 @@
+﻿using System.Net.Mime;
+using Amazon;
+using Amazon.S3;
+using Amazon.S3.Model;
+using DropboxLike.Domain.Configuration;
+using DropboxLike.Domain.Data;
+using Microsoft.Extensions.Options;
+
+namespace DropboxLike.Domain.Repositories.Share;
+
+public class ShareFileRepository
+{
+    private readonly string? _bucketName;
+    private readonly ApplicationDbContext _applicationDbContext;
+    private readonly IAmazonS3 _awsS3Client;
+
+    public ShareFileRepository(IOptions<AwsConfiguration> options, ApplicationDbContext applicationDbContext)
+    {
+        var configuration = options.Value;
+        _bucketName = configuration.BucketName;
+        _awsS3Client = new AmazonS3Client(configuration.AwsAccessKey, configuration.AwsSecretAccessKey, RegionEndpoint.GetBySystemName(configuration.Region));
+        _applicationDbContext = applicationDbContext;
+    }
+
+    public string GeneratePreSignedURL(FileEntity file)
+    {
+        var request = new GetPreSignedUrlRequest
+        {
+            BucketName = _bucketName,
+            Key = file.FileName,
+            ContentType = file.ContentType,
+            Expires = DateTime.UtcNow.AddHours(1)
+        };
+        var preSignedUrl = _awsS3Client.GetPreSignedURL(request);
+
+        return preSignedUrl;
+    }
+}

--- a/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
@@ -14,15 +14,12 @@ public class ShareFileRepository : IShareFileRepository
         _applicationDbContext = applicationDbContext;
     }
 
-    public async Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission)
+    public async Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey)
     {
         var sharedFile = new ShareEntity
         {
             UserId = userId,
             FileId = fileKey,
-            SenderEmail = "",
-            RecipientEmail = "",
-            AccessPermissions = requiredPermission
         };
         await _applicationDbContext.SharedFiles!.AddAsync(sharedFile);
         await _applicationDbContext.SaveChangesAsync();
@@ -30,10 +27,10 @@ public class ShareFileRepository : IShareFileRepository
         return OperationResult<string>.Success("File share successfully");
     }
 
-    public async Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission)
+    public async Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId)
     {
         var sharedFiles = await _applicationDbContext.SharedFiles!
-            .Where(file => file.UserId == userId && file.AccessPermissions == requiredPermission)
+            .Where(file => file.UserId == userId)
             .Join(
                 _applicationDbContext.FileModels!,
                 sharedFile => sharedFile.FileId,

--- a/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
+++ b/DropboxLike.Domain/Repositories/Share/ShareFileRepository.cs
@@ -14,7 +14,7 @@ public class ShareFileRepository : IShareFileRepository
         _applicationDbContext = applicationDbContext;
     }
 
-    public async Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey)
+    public async Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission)
     {
         var sharedFile = new ShareEntity
         {
@@ -22,7 +22,7 @@ public class ShareFileRepository : IShareFileRepository
             FileId = fileKey,
             SenderEmail = "",
             RecipientEmail = "",
-            AccessPermissions = ""
+            AccessPermissions = requiredPermission
         };
         await _applicationDbContext.SharedFiles!.AddAsync(sharedFile);
         await _applicationDbContext.SaveChangesAsync();
@@ -30,10 +30,10 @@ public class ShareFileRepository : IShareFileRepository
         return OperationResult<string>.Success("File share successfully");
     }
 
-    public async Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId)
+    public async Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission)
     {
         var sharedFiles = await _applicationDbContext.SharedFiles!
-            .Where(file => file.UserId == userId)
+            .Where(file => file.UserId == userId && file.AccessPermissions == requiredPermission)
             .Join(
                 _applicationDbContext.FileModels!,
                 sharedFile => sharedFile.FileId,

--- a/DropboxLike.Domain/Repositories/User/IUserRepository.cs
+++ b/DropboxLike.Domain/Repositories/User/IUserRepository.cs
@@ -6,4 +6,5 @@ namespace DropboxLike.Domain.Repositories.User;
 public interface IUserRepository
 {
     Task<OperationResult<string>> RegisterUserAsync(string email, string password);
+    Task<OperationResult<string>> GetUserIdByEmailAddressAsync(string email);
 }

--- a/DropboxLike.Domain/Repositories/User/IUserRepository.cs
+++ b/DropboxLike.Domain/Repositories/User/IUserRepository.cs
@@ -6,5 +6,5 @@ namespace DropboxLike.Domain.Repositories.User;
 public interface IUserRepository
 {
     Task<OperationResult<string>> RegisterUserAsync(string email, string password);
-    Task<OperationResult<string>> GetUserIdByEmailAddressAsync(string email);
+    Task<List<string>> GetUserIdByEmailAddressAsync(List<string> emails);
 }

--- a/DropboxLike.Domain/Repositories/User/UserRepository.cs
+++ b/DropboxLike.Domain/Repositories/User/UserRepository.cs
@@ -20,7 +20,7 @@ public class UserRepository : IUserRepository
     private readonly string? _bucketName;
 
 
-    public UserRepository(ApplicationDbContext applicationDbContext, IOptions<AwsConfiguration> options)
+    public UserRepository(IOptions<AwsConfiguration> options, ApplicationDbContext applicationDbContext)
     {
         var configuration = options.Value;
         _applicationDbContext = applicationDbContext;
@@ -74,6 +74,25 @@ public class UserRepository : IUserRepository
 
     }
 
+    public async Task<OperationResult<string>> GetUserIdByEmailAddressAsync(string email)
+    {
+        try
+        {
+            var user = await _applicationDbContext.AppUsers!.FirstOrDefaultAsync(u => u.Email == email);
+
+            if (user != null)
+            {
+                return OperationResult<string>.Success(user.Id!);
+            }
+           
+            return OperationResult<string>.Fail("User not found for the provided email address.");
+        }
+        catch (Exception ex)
+        {
+            return OperationResult<string>.Fail("An error occurred while retrieving the user ID.");
+        }
+    }
+    
     private async Task CreateS3BucketFolder(string userId)
     {
         var request = new PutObjectRequest

--- a/DropboxLike.Domain/Services/File/FileService.cs
+++ b/DropboxLike.Domain/Services/File/FileService.cs
@@ -27,7 +27,7 @@ public class FileService : IFileService
         return await _fileRepository.DeleteFileAsync(fileId);
     }
 
-    public async Task<OperationResult<List<FileEntity>>> ListBucketFilesAsync()
+    public async Task<OperationResult<List<FileMetadata>>> ListBucketFilesAsync()
     {
         return await _fileRepository.ListFilesAsync();
     }

--- a/DropboxLike.Domain/Services/File/FileService.cs
+++ b/DropboxLike.Domain/Services/File/FileService.cs
@@ -27,8 +27,8 @@ public class FileService : IFileService
         return await _fileRepository.DeleteFileAsync(fileId);
     }
 
-    public async Task<OperationResult<List<FileMetadata>>> ListBucketFilesAsync()
+    public async Task<OperationResult<List<FileMetadata>>> ListBucketFilesAsync(string userId)
     {
-        return await _fileRepository.ListFilesAsync();
+        return await _fileRepository.ListFilesAsync(userId);
     }
 }

--- a/DropboxLike.Domain/Services/File/IFileService.cs
+++ b/DropboxLike.Domain/Services/File/IFileService.cs
@@ -7,5 +7,5 @@ public interface IFileService
     Task<OperationResult<object>> UploadSingleFileAsync(IFormFile file, string userId);
     Task<OperationResult<Models.File>> DownloadSingleFileAsync(string fileId);
     Task<OperationResult<object>> DeleteSingleFileAsync(string fileId);
-    Task<OperationResult<List<FileEntity>>> ListBucketFilesAsync();
+    Task<OperationResult<List<FileMetadata>>> ListBucketFilesAsync();
 }

--- a/DropboxLike.Domain/Services/File/IFileService.cs
+++ b/DropboxLike.Domain/Services/File/IFileService.cs
@@ -7,5 +7,5 @@ public interface IFileService
     Task<OperationResult<object>> UploadSingleFileAsync(IFormFile file, string userId);
     Task<OperationResult<Models.File>> DownloadSingleFileAsync(string fileId);
     Task<OperationResult<object>> DeleteSingleFileAsync(string fileId);
-    Task<OperationResult<List<FileMetadata>>> ListBucketFilesAsync();
+    Task<OperationResult<List<FileMetadata>>> ListBucketFilesAsync(string userId);
 }

--- a/DropboxLike.Domain/Services/Share/IShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/IShareFileService.cs
@@ -5,7 +5,7 @@ namespace DropboxLike.Domain.Services.Share;
 
 public interface IShareFileService
 {
-    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission);
-    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission);
+    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
+    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey);
 
 }

--- a/DropboxLike.Domain/Services/Share/IShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/IShareFileService.cs
@@ -1,0 +1,8 @@
+﻿using DropboxLike.Domain.Models;
+
+namespace DropboxLike.Domain.Services.Share;
+
+public interface IShareFileService
+{
+    Task<OperationResult<string>> ShareFileServiceAsync(FileEntity file);
+}

--- a/DropboxLike.Domain/Services/Share/IShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/IShareFileService.cs
@@ -4,5 +4,5 @@ namespace DropboxLike.Domain.Services.Share;
 
 public interface IShareFileService
 {
-    Task<OperationResult<string>> ShareFileServiceAsync(FileEntity file);
+    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
 }

--- a/DropboxLike.Domain/Services/Share/IShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/IShareFileService.cs
@@ -5,4 +5,6 @@ namespace DropboxLike.Domain.Services.Share;
 public interface IShareFileService
 {
     Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
+    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey);
+
 }

--- a/DropboxLike.Domain/Services/Share/IShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/IShareFileService.cs
@@ -1,10 +1,11 @@
-﻿using DropboxLike.Domain.Models;
+﻿using DropboxLike.Domain.Data.Entities;
+using DropboxLike.Domain.Models;
 
 namespace DropboxLike.Domain.Services.Share;
 
 public interface IShareFileService
 {
-    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId);
-    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey);
+    Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission);
+    Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission);
 
 }

--- a/DropboxLike.Domain/Services/Share/ShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/ShareFileService.cs
@@ -16,4 +16,9 @@ public class ShareFileService : IShareFileService
     {
         return _shareFileRepository.GetSharedFilesByUserId(userId);
     }
+
+    public Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey)
+    {
+        return _shareFileRepository.ShareFileWithUserAsync(userId, fileKey);
+    }
 }

--- a/DropboxLike.Domain/Services/Share/ShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/ShareFileService.cs
@@ -12,8 +12,8 @@ public class ShareFileService : IShareFileService
         _shareFileRepository = shareFileRepository;
     }
     
-    public Task<OperationResult<string>> ShareFileServiceAsync(FileEntity file)
+    public Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId)
     {
-        return _shareFileRepository.SharedFileWithEmail(file);
+        return _shareFileRepository.GetSharedFilesByUserId(userId);
     }
 }

--- a/DropboxLike.Domain/Services/Share/ShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/ShareFileService.cs
@@ -13,13 +13,13 @@ public class ShareFileService : IShareFileService
         _shareFileRepository = shareFileRepository;
     }
     
-    public Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission)
+    public Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId)
     {
-        return _shareFileRepository.GetSharedFilesByUserId(userId, requiredPermission);
+        return _shareFileRepository.GetSharedFilesByUserId(userId);
     }
 
-    public Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission)
+    public Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey)
     {
-        return _shareFileRepository.ShareFileWithUserAsync(userId, fileKey, requiredPermission);
+        return _shareFileRepository.ShareFileWithUserAsync(userId, fileKey);
     }
 }

--- a/DropboxLike.Domain/Services/Share/ShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/ShareFileService.cs
@@ -1,0 +1,19 @@
+﻿using DropboxLike.Domain.Models;
+using DropboxLike.Domain.Repositories.Share;
+
+namespace DropboxLike.Domain.Services.Share;
+
+public class ShareFileService : IShareFileService
+{
+    private readonly IShareFileRepository _shareFileRepository;
+
+    public ShareFileService(IShareFileRepository shareFileRepository)
+    {
+        _shareFileRepository = shareFileRepository;
+    }
+    
+    public Task<OperationResult<string>> ShareFileServiceAsync(FileEntity file)
+    {
+        return _shareFileRepository.SharedFileWithEmail(file);
+    }
+}

--- a/DropboxLike.Domain/Services/Share/ShareFileService.cs
+++ b/DropboxLike.Domain/Services/Share/ShareFileService.cs
@@ -1,4 +1,5 @@
-﻿using DropboxLike.Domain.Models;
+﻿using DropboxLike.Domain.Data.Entities;
+using DropboxLike.Domain.Models;
 using DropboxLike.Domain.Repositories.Share;
 
 namespace DropboxLike.Domain.Services.Share;
@@ -12,13 +13,13 @@ public class ShareFileService : IShareFileService
         _shareFileRepository = shareFileRepository;
     }
     
-    public Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId)
+    public Task<OperationResult<List<FileMetadata>>> GetSharedFilesByUserId(string userId, AccessPermission requiredPermission)
     {
-        return _shareFileRepository.GetSharedFilesByUserId(userId);
+        return _shareFileRepository.GetSharedFilesByUserId(userId, requiredPermission);
     }
 
-    public Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey)
+    public Task<OperationResult<string>> ShareFileWithUserAsync(string userId, string fileKey, AccessPermission requiredPermission)
     {
-        return _shareFileRepository.ShareFileWithUserAsync(userId, fileKey);
+        return _shareFileRepository.ShareFileWithUserAsync(userId, fileKey, requiredPermission);
     }
 }

--- a/DropboxLike.Domain/Services/Token/TokenManager.cs
+++ b/DropboxLike.Domain/Services/Token/TokenManager.cs
@@ -18,6 +18,7 @@ public class TokenManager : ITokenManager
 
     public TokenManager(ApplicationDbContext applicationDbContext)
     {
+        // TODO: Inject a repository instead, this is a service layer component that should not touch DB context at all.
         _applicationDbContext = applicationDbContext;
         _tokenHandler = new JwtSecurityTokenHandler();
         _secretKey = Convert.FromBase64String(Convert.ToBase64String(Encoding.UTF8.GetBytes("rekfjdhabdjekkrnabrisnakelsntjsn")));
@@ -51,6 +52,7 @@ public class TokenManager : ITokenManager
         }
     }
 
+    // TODO: Move this method into a repository.
     private async Task<UserEntity?> GetUserByEmail(string email)
     {
         var user = await _applicationDbContext.AppUsers.FirstOrDefaultAsync(u => u.Email == email);

--- a/DropboxLike.Domain/Services/User/IUserService.cs
+++ b/DropboxLike.Domain/Services/User/IUserService.cs
@@ -6,4 +6,5 @@ namespace DropboxLike.Domain.Services.User;
 public interface IUserService
 {
     Task<OperationResult<string>> RegisterUserAsync(string email, string password);
+    Task<OperationResult<string>> GetUserIdByEmailAddressAsync(string email);
 }

--- a/DropboxLike.Domain/Services/User/IUserService.cs
+++ b/DropboxLike.Domain/Services/User/IUserService.cs
@@ -6,5 +6,5 @@ namespace DropboxLike.Domain.Services.User;
 public interface IUserService
 {
     Task<OperationResult<string>> RegisterUserAsync(string email, string password);
-    Task<OperationResult<string>> GetUserIdByEmailAddressAsync(string email);
+    Task<List<string>> GetUserIdByEmailAddressAsync(List<string> emails);
 }

--- a/DropboxLike.Domain/Services/User/UserService.cs
+++ b/DropboxLike.Domain/Services/User/UserService.cs
@@ -17,4 +17,9 @@ public class UserService : IUserService
     {
         return await _userRepository.RegisterUserAsync(email, password);
     }
+
+    public async Task<OperationResult<string>> GetUserIdByEmailAddressAsync(string email)
+    {
+        return await _userRepository.GetUserIdByEmailAddressAsync(email);
+    }
 }

--- a/DropboxLike.Domain/Services/User/UserService.cs
+++ b/DropboxLike.Domain/Services/User/UserService.cs
@@ -18,8 +18,8 @@ public class UserService : IUserService
         return await _userRepository.RegisterUserAsync(email, password);
     }
 
-    public async Task<OperationResult<string>> GetUserIdByEmailAddressAsync(string email)
+    public async Task<List<string>> GetUserIdByEmailAddressAsync(List<string> emails)
     {
-        return await _userRepository.GetUserIdByEmailAddressAsync(email);
+        return await _userRepository.GetUserIdByEmailAddressAsync(emails);
     }
 }


### PR DESCRIPTION
## Suggested steps
- Generate Short-Lived Pre-Signed URLs
- Store Metadata for Shared Files
- Implement Access Renewal Logic - Create a background task or a `scheduled cron job` in that periodically checks the shared file metadata in the database. For files that are still valid and not deleted by the owner, and for which the access expiration timestamp is about to expire, renew or extend the access for the recipient.
- Send Updated Pre-Signed URLs to Recipients - After renewing the access, send the updated pre-signed URLs to the recipients via email or any other notification method
- Handle Revocation - If the owner decides to revoke access to a shared file, it should promptly update the file's metadata in the database and invalidate any existing pre-signed URLs associated with the file